### PR TITLE
[Feat] OAuth 2.0를 활용한 로그인 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,6 +26,12 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+
+    //jwt
+    implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
+    runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 
     // p6spy
     implementation 'com.github.gavlyukovskiy:p6spy-spring-boot-starter:1.9.0'
@@ -41,6 +47,7 @@ dependencies {
     testRuntimeOnly 'com.h2database:h2'
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'org.springframework.security:spring-security-test'
 }
 
 tasks.named('bootBuildImage') {

--- a/src/main/java/cotato/bookitlist/BookitlistApplication.java
+++ b/src/main/java/cotato/bookitlist/BookitlistApplication.java
@@ -2,12 +2,14 @@ package cotato.bookitlist;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
 
+@ConfigurationPropertiesScan
 @SpringBootApplication
 public class BookitlistApplication {
 
-	public static void main(String[] args) {
-		SpringApplication.run(BookitlistApplication.class, args);
-	}
+    public static void main(String[] args) {
+        SpringApplication.run(BookitlistApplication.class, args);
+    }
 
 }

--- a/src/main/java/cotato/bookitlist/config/security/SecurityConfig.java
+++ b/src/main/java/cotato/bookitlist/config/security/SecurityConfig.java
@@ -1,0 +1,50 @@
+package cotato.bookitlist.config.security;
+
+import cotato.bookitlist.config.security.jwt.JwtTokenProvider;
+import cotato.bookitlist.config.security.oauth.service.CustomOAuth2UserService;
+import cotato.bookitlist.config.security.oauth.handler.OAuth2AuthenticationSuccessHandler;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.annotation.web.configurers.HeadersConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+
+@RequiredArgsConstructor
+@EnableWebSecurity
+@Configuration
+public class SecurityConfig {
+    private final CustomOAuth2UserService customOAuth2UserService;
+    private final OAuth2AuthenticationSuccessHandler oAuth2AuthenticationSuccessHandler;
+    private final String[] WHITE_LIST = {
+            "/health_check",
+            "/swagger-ui/**",
+            "/h2-console/**"
+    };
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http
+                .csrf(AbstractHttpConfigurer::disable)
+                .headers(headers -> headers.frameOptions(HeadersConfigurer.FrameOptionsConfig::disable).disable())
+                .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers(WHITE_LIST).permitAll()
+                        .requestMatchers(HttpMethod.GET).permitAll()
+                        .anyRequest().authenticated()
+                )
+                .oauth2Login(oauth2 -> oauth2
+                        .userInfoEndpoint((userInfo) -> userInfo.userService(this.customOAuth2UserService))
+                        .successHandler(this.oAuth2AuthenticationSuccessHandler))
+                .exceptionHandling(exception ->
+                        exception.authenticationEntryPoint((request, response, authException) ->
+                                response.sendError(HttpServletResponse.SC_FORBIDDEN)));
+        return http.build();
+    }
+
+}

--- a/src/main/java/cotato/bookitlist/config/security/SecurityConfig.java
+++ b/src/main/java/cotato/bookitlist/config/security/SecurityConfig.java
@@ -1,5 +1,6 @@
 package cotato.bookitlist.config.security;
 
+import cotato.bookitlist.config.security.jwt.JwtAuthenticationFilter;
 import cotato.bookitlist.config.security.jwt.JwtTokenProvider;
 import cotato.bookitlist.config.security.oauth.service.CustomOAuth2UserService;
 import cotato.bookitlist.config.security.oauth.handler.OAuth2AuthenticationSuccessHandler;
@@ -14,6 +15,7 @@ import org.springframework.security.config.annotation.web.configurers.AbstractHt
 import org.springframework.security.config.annotation.web.configurers.HeadersConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 @RequiredArgsConstructor
 @EnableWebSecurity
@@ -21,6 +23,7 @@ import org.springframework.security.web.SecurityFilterChain;
 public class SecurityConfig {
     private final CustomOAuth2UserService customOAuth2UserService;
     private final OAuth2AuthenticationSuccessHandler oAuth2AuthenticationSuccessHandler;
+    private final JwtTokenProvider jwtTokenProvider;
     private final String[] WHITE_LIST = {
             "/health_check",
             "/swagger-ui/**",
@@ -41,6 +44,8 @@ public class SecurityConfig {
                 .oauth2Login(oauth2 -> oauth2
                         .userInfoEndpoint((userInfo) -> userInfo.userService(this.customOAuth2UserService))
                         .successHandler(this.oAuth2AuthenticationSuccessHandler))
+                .addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider), UsernamePasswordAuthenticationFilter.class)
+
                 .exceptionHandling(exception ->
                         exception.authenticationEntryPoint((request, response, authException) ->
                                 response.sendError(HttpServletResponse.SC_FORBIDDEN)));

--- a/src/main/java/cotato/bookitlist/config/security/jwt/AuthDetails.java
+++ b/src/main/java/cotato/bookitlist/config/security/jwt/AuthDetails.java
@@ -1,0 +1,54 @@
+package cotato.bookitlist.config.security.jwt;
+
+import java.util.Collection;
+import java.util.Collections;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+@AllArgsConstructor
+@Getter
+public class AuthDetails implements UserDetails {
+
+    private String userId;
+
+    private String role;
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return Collections.singleton(new SimpleGrantedAuthority("ROLE_" + role));
+    }
+
+    @Override
+    public String getPassword() {
+        return null;
+    }
+
+    @Override
+    public String getUsername() {
+        return userId;
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return true;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return true;
+    }
+}

--- a/src/main/java/cotato/bookitlist/config/security/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/cotato/bookitlist/config/security/jwt/JwtAuthenticationFilter.java
@@ -47,7 +47,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     public Authentication getAuthentication(String token) {
         AccessTokenInfo accessTokenInfo = this.jwtTokenProvider.parseAccessToken(token);
-        UserDetails userDetails = new AuthDetails(accessTokenInfo.getUserId().toString(), accessTokenInfo.getRole());
+        UserDetails userDetails = new AuthDetails(accessTokenInfo.userId().toString(), accessTokenInfo.role());
         return new UsernamePasswordAuthenticationToken(userDetails, "user", userDetails.getAuthorities());
     }
 

--- a/src/main/java/cotato/bookitlist/config/security/jwt/JwtTokenProvider.java
+++ b/src/main/java/cotato/bookitlist/config/security/jwt/JwtTokenProvider.java
@@ -62,14 +62,14 @@ public class JwtTokenProvider {
 
     public String generateAccessToken(Long id, String role) {
         Date issuedAt = new Date();
-        Date accessTokenExpiresIn = new Date(issuedAt.getTime() + jwtProperties.getAccessExp() * 1000);
+        Date accessTokenExpiresIn = new Date(issuedAt.getTime() + getAccessTokenTTlSecond() * 1000);
 
         return buildAccessToken(id, issuedAt, accessTokenExpiresIn, role);
     }
 
     public String generateRefreshToken(Long id) {
         Date issuedAt = new Date();
-        Date refreshTokenExpiresIn = new Date(issuedAt.getTime() + jwtProperties.getRefreshExp() * 1000);
+        Date refreshTokenExpiresIn = new Date(issuedAt.getTime() + getRefreshTokenTTlSecond() * 1000);
 
         return buildRefreshToken(id, issuedAt, refreshTokenExpiresIn);
     }
@@ -85,10 +85,10 @@ public class JwtTokenProvider {
     public AccessTokenInfo parseAccessToken(String token) {
         if (isAccessToken(token)) {
             Claims claims = getJws(token).getBody();
-            return AccessTokenInfo.builder()
-                    .userId(Long.parseLong(claims.getSubject()))
-                    .role((String) claims.get("role"))
-                    .build();
+            return AccessTokenInfo.of(
+                    Long.parseLong(claims.getSubject()),
+                    (String) claims.get("role")
+            );
         } else {
             throw new RuntimeException();
         }

--- a/src/main/java/cotato/bookitlist/config/security/jwt/JwtTokenProvider.java
+++ b/src/main/java/cotato/bookitlist/config/security/jwt/JwtTokenProvider.java
@@ -1,0 +1,118 @@
+package cotato.bookitlist.config.security.jwt;
+
+import cotato.bookitlist.config.security.jwt.dto.AccessTokenInfo;
+import cotato.bookitlist.config.security.jwt.properties.JwtProperties;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.Jws;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+
+import java.nio.charset.StandardCharsets;
+import java.security.Key;
+import java.util.Date;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@RequiredArgsConstructor
+@Component
+public class JwtTokenProvider {
+
+    private final JwtProperties jwtProperties;
+
+    private Jws<Claims> getJws(String token) {
+        try {
+            return Jwts.parserBuilder().setSigningKey(getSecretKey()).build().parseClaimsJws(token);
+        } catch (ExpiredJwtException ex) {
+            throw new RuntimeException();
+        } catch (Exception ex) {
+            throw new RuntimeException();
+        }
+    }
+
+    private Key getSecretKey() {
+        return Keys.hmacShaKeyFor(jwtProperties.getSecretKey().getBytes(StandardCharsets.UTF_8));
+    }
+
+    private String buildAccessToken(Long id, Date issuedAt, Date accessTokenExpiresIn, String role) {
+        final Key encodedKey = getSecretKey();
+        return Jwts.builder()
+                .setIssuer("bookitlist")
+                .setIssuedAt(issuedAt)
+                .setSubject(id.toString())
+                .claim("type", "ACCESS_TOKEN")
+                .claim("role", role)
+                .setExpiration(accessTokenExpiresIn)
+                .signWith(encodedKey)
+                .compact();
+    }
+
+    private String buildRefreshToken(Long id, Date issuedAt, Date accessTokenExpiresIn) {
+        Key encodedKey = getSecretKey();
+        return Jwts.builder()
+                .setIssuer("bookitlist")
+                .setIssuedAt(issuedAt)
+                .setSubject(id.toString())
+                .claim("type", "REFRESH_TOKEN")
+                .setExpiration(accessTokenExpiresIn)
+                .signWith(encodedKey)
+                .compact();
+    }
+
+    public String generateAccessToken(Long id, String role) {
+        Date issuedAt = new Date();
+        Date accessTokenExpiresIn = new Date(issuedAt.getTime() + jwtProperties.getAccessExp() * 1000);
+
+        return buildAccessToken(id, issuedAt, accessTokenExpiresIn, role);
+    }
+
+    public String generateRefreshToken(Long id) {
+        Date issuedAt = new Date();
+        Date refreshTokenExpiresIn = new Date(issuedAt.getTime() + jwtProperties.getRefreshExp() * 1000);
+
+        return buildRefreshToken(id, issuedAt, refreshTokenExpiresIn);
+    }
+
+    public boolean isAccessToken(String token) {
+        return getJws(token).getBody().get("type").equals("ACCESS_TOKEN");
+    }
+
+    public boolean isRefreshToken(String token) {
+        return getJws(token).getBody().get("type").equals("REFRESH_TOKEN");
+    }
+
+    public AccessTokenInfo parseAccessToken(String token) {
+        if (isAccessToken(token)) {
+            Claims claims = getJws(token).getBody();
+            return AccessTokenInfo.builder()
+                    .userId(Long.parseLong(claims.getSubject()))
+                    .role((String) claims.get("role"))
+                    .build();
+        } else {
+            throw new RuntimeException();
+        }
+    }
+
+    public Long parseRefreshToken(String token) {
+        try {
+            if (isRefreshToken(token)) {
+                Claims claims = getJws(token).getBody();
+                return Long.parseLong(claims.getSubject());
+            }
+        } catch (ExpiredJwtException ex) {
+            throw new RuntimeException();
+        }
+
+        throw new RuntimeException();
+    }
+
+    public Long getRefreshTokenTTlSecond() {
+        return jwtProperties.getRefreshExp();
+    }
+
+    public Long getAccessTokenTTlSecond() {
+        return jwtProperties.getAccessExp();
+    }
+
+}

--- a/src/main/java/cotato/bookitlist/config/security/jwt/dto/AccessTokenInfo.java
+++ b/src/main/java/cotato/bookitlist/config/security/jwt/dto/AccessTokenInfo.java
@@ -1,0 +1,11 @@
+package cotato.bookitlist.config.security.jwt.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class AccessTokenInfo {
+    private final Long userId;
+    private final String role;
+}

--- a/src/main/java/cotato/bookitlist/config/security/jwt/dto/AccessTokenInfo.java
+++ b/src/main/java/cotato/bookitlist/config/security/jwt/dto/AccessTokenInfo.java
@@ -1,11 +1,11 @@
 package cotato.bookitlist.config.security.jwt.dto;
 
-import lombok.Builder;
-import lombok.Getter;
+public record AccessTokenInfo(
+        Long userId,
+        String role
+) {
+    public static AccessTokenInfo of(Long userId, String role) {
+        return new AccessTokenInfo(userId, role);
+    }
 
-@Getter
-@Builder
-public class AccessTokenInfo {
-    private final Long userId;
-    private final String role;
 }

--- a/src/main/java/cotato/bookitlist/config/security/jwt/properties/JwtProperties.java
+++ b/src/main/java/cotato/bookitlist/config/security/jwt/properties/JwtProperties.java
@@ -1,0 +1,14 @@
+package cotato.bookitlist.config.security.jwt.properties;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@Getter
+@AllArgsConstructor
+@ConfigurationProperties(prefix = "auth.jwt")
+public class JwtProperties {
+    private String secretKey;
+    private Long accessExp;
+    private Long refreshExp;
+}

--- a/src/main/java/cotato/bookitlist/config/security/oauth/AuthProvider.java
+++ b/src/main/java/cotato/bookitlist/config/security/oauth/AuthProvider.java
@@ -2,8 +2,6 @@ package cotato.bookitlist.config.security.oauth;
 
 public enum AuthProvider {
     KAKAO,
-    NAVER;
+    NAVER,
 
-    AuthProvider() {
-    }
 }

--- a/src/main/java/cotato/bookitlist/config/security/oauth/AuthProvider.java
+++ b/src/main/java/cotato/bookitlist/config/security/oauth/AuthProvider.java
@@ -1,0 +1,9 @@
+package cotato.bookitlist.config.security.oauth;
+
+public enum AuthProvider {
+    KAKAO,
+    NAVER;
+
+    AuthProvider() {
+    }
+}

--- a/src/main/java/cotato/bookitlist/config/security/oauth/KakaoOAuth2User.java
+++ b/src/main/java/cotato/bookitlist/config/security/oauth/KakaoOAuth2User.java
@@ -1,0 +1,27 @@
+package cotato.bookitlist.config.security.oauth;
+
+import java.util.Map;
+
+public class KakaoOAuth2User extends OAuth2UserInfo {
+    private final Long id;
+
+    public KakaoOAuth2User(Map<String, Object> attributes) {
+        super((Map) attributes.get("kakao_account"));
+        this.id = (Long) attributes.get("id");
+    }
+
+    @Override
+    public String getOAuth2Id() {
+        return this.id.toString();
+    }
+
+    @Override
+    public String getEmail() {
+        return (String) this.attributes.get("email");
+    }
+
+    @Override
+    public String getName() {
+        return (String) ((Map) this.attributes.get("profile")).get("nickname");
+    }
+}

--- a/src/main/java/cotato/bookitlist/config/security/oauth/NaverOAuth2User.java
+++ b/src/main/java/cotato/bookitlist/config/security/oauth/NaverOAuth2User.java
@@ -1,0 +1,21 @@
+package cotato.bookitlist.config.security.oauth;
+
+import java.util.Map;
+
+public class NaverOAuth2User extends OAuth2UserInfo {
+    public NaverOAuth2User(Map<String, Object> attributes) {
+        super((Map) attributes.get("response"));
+    }
+
+    public String getOAuth2Id() {
+        return (String) this.attributes.get("id");
+    }
+
+    public String getEmail() {
+        return (String) this.attributes.get("email");
+    }
+
+    public String getName() {
+        return (String) this.attributes.get("name");
+    }
+}

--- a/src/main/java/cotato/bookitlist/config/security/oauth/OAuth2UserInfo.java
+++ b/src/main/java/cotato/bookitlist/config/security/oauth/OAuth2UserInfo.java
@@ -1,0 +1,19 @@
+package cotato.bookitlist.config.security.oauth;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.Map;
+
+@Getter
+@AllArgsConstructor
+public abstract class OAuth2UserInfo {
+    protected Map<String, Object> attributes;
+
+    public abstract String getOAuth2Id();
+
+    public abstract String getEmail();
+
+    public abstract String getName();
+
+}

--- a/src/main/java/cotato/bookitlist/config/security/oauth/OAuth2UserInfoFactory.java
+++ b/src/main/java/cotato/bookitlist/config/security/oauth/OAuth2UserInfoFactory.java
@@ -1,0 +1,13 @@
+package cotato.bookitlist.config.security.oauth;
+
+import java.util.Map;
+
+public class OAuth2UserInfoFactory {
+
+    public static OAuth2UserInfo getOAuth2UserInfo(AuthProvider authProvider, Map<String, Object> attributes) {
+        return switch (authProvider) {
+            case NAVER -> new NaverOAuth2User(attributes);
+            case KAKAO -> new KakaoOAuth2User(attributes);
+        };
+    }
+}

--- a/src/main/java/cotato/bookitlist/config/security/oauth/UserPrincipal.java
+++ b/src/main/java/cotato/bookitlist/config/security/oauth/UserPrincipal.java
@@ -1,0 +1,88 @@
+package cotato.bookitlist.config.security.oauth;
+
+import cotato.bookitlist.member.domain.Member;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+
+@Getter
+@AllArgsConstructor
+public class UserPrincipal implements OAuth2User, UserDetails {
+
+    private Long id;
+    private String email;
+    private Collection<? extends GrantedAuthority> authorities;
+
+    @Setter
+    private Map<String, Object> attributes;
+
+    public UserPrincipal(Long id, String email, Collection<? extends GrantedAuthority> authorities) {
+        this.id = id;
+        this.email = email;
+        this.authorities = authorities;
+    }
+
+    // TODO: Role 추가해야함!!
+    public static UserPrincipal create(Member member, Map<String, Object> attributes) {
+//        List<GrantedAuthority> authorities = Collections.singletonList(new SimpleGrantedAuthority(Role.ROLE_USER.name()));
+        List<GrantedAuthority> authorities = Collections.singletonList(new SimpleGrantedAuthority("USER"));
+        UserPrincipal userPrincipal = new UserPrincipal(member.getId(), member.getEmail(), authorities);
+        userPrincipal.setAttributes(attributes);
+        return userPrincipal;
+    }
+
+    @Override
+    public String getUsername() {
+        return email;
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return true;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return true;
+    }
+
+    @Override
+    public Map<String, Object> getAttributes() {
+        return null;
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return authorities;
+    }
+
+    @Override
+    public String getPassword() {
+        return null;
+    }
+
+    @Override
+    public String getName() {
+        return String.valueOf(id);
+    }
+}

--- a/src/main/java/cotato/bookitlist/config/security/oauth/handler/OAuth2AuthenticationSuccessHandler.java
+++ b/src/main/java/cotato/bookitlist/config/security/oauth/handler/OAuth2AuthenticationSuccessHandler.java
@@ -1,0 +1,42 @@
+package cotato.bookitlist.config.security.oauth.handler;
+
+import cotato.bookitlist.config.security.jwt.JwtTokenProvider;
+import cotato.bookitlist.config.security.oauth.UserPrincipal;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import java.io.IOException;
+import java.util.stream.Collectors;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
+import org.springframework.stereotype.Component;
+import org.springframework.web.util.UriComponentsBuilder;
+
+@Slf4j
+@Component
+public class OAuth2AuthenticationSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
+    @Value("${oauth.authorizedRedirectUri}")
+    private String redirectUri;
+    private final JwtTokenProvider jwtTokenProvider;
+
+    public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException {
+        if (response.isCommitted()) {
+            log.debug("Response has already been committed.");
+        } else {
+            UserPrincipal userDetails = (UserPrincipal) authentication.getPrincipal();
+            Long id = userDetails.getId();
+            String authorities = authentication.getAuthorities().stream().map(GrantedAuthority::getAuthority).collect(Collectors.joining(","));
+            String accessToken = this.jwtTokenProvider.generateAccessToken(id, authorities);
+            String uri = UriComponentsBuilder.fromUriString(this.redirectUri).queryParam("accessToken", accessToken).toUriString();
+            this.getRedirectStrategy().sendRedirect(request, response, uri);
+        }
+    }
+
+    public OAuth2AuthenticationSuccessHandler(final JwtTokenProvider jwtTokenProvider) {
+        this.jwtTokenProvider = jwtTokenProvider;
+    }
+}

--- a/src/main/java/cotato/bookitlist/config/security/oauth/service/CustomOAuth2UserService.java
+++ b/src/main/java/cotato/bookitlist/config/security/oauth/service/CustomOAuth2UserService.java
@@ -1,0 +1,49 @@
+package cotato.bookitlist.config.security.oauth.service;
+
+import cotato.bookitlist.config.security.oauth.AuthProvider;
+import cotato.bookitlist.config.security.oauth.OAuth2UserInfo;
+import cotato.bookitlist.config.security.oauth.OAuth2UserInfoFactory;
+import cotato.bookitlist.config.security.oauth.UserPrincipal;
+import cotato.bookitlist.member.domain.Member;
+import cotato.bookitlist.member.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserService;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Service
+public class CustomOAuth2UserService implements OAuth2UserService<OAuth2UserRequest, OAuth2User> {
+    private final MemberRepository memberRepository;
+
+    public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
+        OAuth2UserService<OAuth2UserRequest, OAuth2User> oAuth2UserService = new DefaultOAuth2UserService();
+        OAuth2User oAuth2User = oAuth2UserService.loadUser(userRequest);
+        return processOAuth2User(userRequest, oAuth2User);
+    }
+
+    private OAuth2User processOAuth2User(OAuth2UserRequest userRequest, OAuth2User oAuth2User) {
+        AuthProvider authProvider = AuthProvider.valueOf(userRequest.getClientRegistration().getRegistrationId().toUpperCase());
+        OAuth2UserInfo oAuth2UserInfo = OAuth2UserInfoFactory.getOAuth2UserInfo(authProvider, oAuth2User.getAttributes());
+        Member member = memberRepository.findByEmail(oAuth2UserInfo.getEmail());
+        if (member != null) {
+            member = updateMember(member, oAuth2UserInfo);
+        } else {
+            member = registerMember(authProvider, oAuth2UserInfo);
+        }
+        return UserPrincipal.create(member, oAuth2UserInfo.getAttributes());
+    }
+
+    private Member registerMember(AuthProvider authProvider, OAuth2UserInfo oAuth2UserInfo) {
+        Member member = Member.of(authProvider, oAuth2UserInfo);
+        return memberRepository.save(member);
+    }
+
+    private Member updateMember(Member member, OAuth2UserInfo oAuth2UserInfo) {
+        return member.update(oAuth2UserInfo);
+    }
+
+}

--- a/src/main/java/cotato/bookitlist/config/security/oauth/service/CustomOAuth2UserService.java
+++ b/src/main/java/cotato/bookitlist/config/security/oauth/service/CustomOAuth2UserService.java
@@ -13,9 +13,11 @@ import org.springframework.security.oauth2.client.userinfo.OAuth2UserService;
 import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
-@RequiredArgsConstructor
 @Service
+@Transactional
+@RequiredArgsConstructor
 public class CustomOAuth2UserService implements OAuth2UserService<OAuth2UserRequest, OAuth2User> {
     private final MemberRepository memberRepository;
 

--- a/src/main/java/cotato/bookitlist/config/security/oauth/service/CustomOAuth2UserService.java
+++ b/src/main/java/cotato/bookitlist/config/security/oauth/service/CustomOAuth2UserService.java
@@ -30,7 +30,7 @@ public class CustomOAuth2UserService implements OAuth2UserService<OAuth2UserRequ
     private OAuth2User processOAuth2User(OAuth2UserRequest userRequest, OAuth2User oAuth2User) {
         AuthProvider authProvider = AuthProvider.valueOf(userRequest.getClientRegistration().getRegistrationId().toUpperCase());
         OAuth2UserInfo oAuth2UserInfo = OAuth2UserInfoFactory.getOAuth2UserInfo(authProvider, oAuth2User.getAttributes());
-        Member member = memberRepository.findByEmail(oAuth2UserInfo.getEmail());
+        Member member = memberRepository.findByOauth2IdAndAuthProvider(oAuth2UserInfo.getOAuth2Id(), authProvider);
         if (member != null) {
             member = updateMember(member, oAuth2UserInfo);
         } else {

--- a/src/main/java/cotato/bookitlist/member/domain/Member.java
+++ b/src/main/java/cotato/bookitlist/member/domain/Member.java
@@ -34,4 +34,23 @@ public class Member extends BaseEntity {
     private int followCount = 0;
 
     private boolean deleted = false;
+
+    public Member(String email, String name, String oauth2Id, AuthProvider authProvider) {
+        this.email = email;
+        this.name = name;
+        this.oauth2Id = oauth2Id;
+        this.authProvider = authProvider;
+    }
+
+    public static Member of(AuthProvider authProvider, OAuth2UserInfo oAuth2UserInfo) {
+        return new Member(oAuth2UserInfo.getEmail(), oAuth2UserInfo.getName(), oAuth2UserInfo.getOAuth2Id(),
+                authProvider);
+    }
+
+    public Member update(OAuth2UserInfo oAuth2UserInfo) {
+        this.name = oAuth2UserInfo.getName();
+        this.oauth2Id = oAuth2UserInfo.getOAuth2Id();
+
+        return this;
+    }
 }

--- a/src/main/java/cotato/bookitlist/member/domain/Member.java
+++ b/src/main/java/cotato/bookitlist/member/domain/Member.java
@@ -1,13 +1,17 @@
 package cotato.bookitlist.member.domain;
 
 import cotato.bookitlist.common.domain.BaseEntity;
+import cotato.bookitlist.config.security.oauth.AuthProvider;
+import cotato.bookitlist.config.security.oauth.OAuth2UserInfo;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.Where;
 
 @Entity
+@Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @SQLDelete(sql = "UPDATE member SET deleted = true WHERE member_id = ?")
 @Where(clause = "deleted = false")
@@ -17,6 +21,15 @@ public class Member extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "member_id")
     private Long id;
+
+    private String email;
+
+    private String name;
+
+    private String oauth2Id;
+
+    @Enumerated(EnumType.STRING)
+    private AuthProvider authProvider;
 
     private int followCount = 0;
 

--- a/src/main/java/cotato/bookitlist/member/repository/MemberRepository.java
+++ b/src/main/java/cotato/bookitlist/member/repository/MemberRepository.java
@@ -1,9 +1,10 @@
 package cotato.bookitlist.member.repository;
 
+import cotato.bookitlist.config.security.oauth.AuthProvider;
 import cotato.bookitlist.member.domain.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
 
-    Member findByEmail(String email);
+    Member findByOauth2IdAndAuthProvider(String oauth2Id, AuthProvider authProvider);
 }

--- a/src/main/java/cotato/bookitlist/member/repository/MemberRepository.java
+++ b/src/main/java/cotato/bookitlist/member/repository/MemberRepository.java
@@ -1,0 +1,9 @@
+package cotato.bookitlist.member.repository;
+
+import cotato.bookitlist.member.domain.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MemberRepository extends JpaRepository<Member, Long> {
+
+    Member findByEmail(String email);
+}

--- a/src/main/resources/application-oauth.yaml
+++ b/src/main/resources/application-oauth.yaml
@@ -1,0 +1,33 @@
+spring:
+  security:
+    oauth2:
+      client:
+        registration:
+          naver:
+            client-name: Naver
+            redirect-uri: http://localhost:8080//login/oauth2/code/naver
+            authorization-grant-type: authorization_code
+            client-id: ${NAVER_CLIENT_ID}
+            client-secret: ${NAVER_CLIENT_SECRET}
+          kakao:
+            client-name: Kakao
+            client-authentication-method: client_secret_post
+            redirect-uri: http://localhost:8080/login/oauth2/code/kakao
+            authorization-grant-type: authorization_code
+            client-id: ${KAKAO_CLIENT_ID}
+            client-secret: ${KAKAO_CLIENT_SECRET}
+            scope: account_email,profile_nickname
+        provider:
+          kakao:
+            user-name-attribute: id
+            authorization-uri: https://kauth.kakao.com/oauth/authorize
+            token-uri: https://kauth.kakao.com/oauth/token
+            user-info-uri: https://kapi.kakao.com/v2/user/me
+          naver:
+            user-name-attribute: response
+            authorization-uri: https://nid.naver.com/oauth2.0/authorize
+            user-info-uri: https://openapi.naver.com/v1/nid/me
+            token-uri: https://nid.naver.com/oauth2.0/token
+
+oauth:
+  authorizedRedirectUri: http://localhost:3000/login/redirected

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -19,6 +19,15 @@ spring:
       host: localhost
       port: 6379
 
+  profiles:
+    include: oauth
+
 api:
   aladin:
     key: ${ALADIN_KEY}
+
+auth:
+  jwt:
+    secretKey: ${JWT_SECRET}
+    accessExp: 3600
+    refreshExp: 86400

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -30,4 +30,4 @@ auth:
   jwt:
     secretKey: ${JWT_SECRET}
     accessExp: 3600
-    refreshExp: 86400
+    refreshExp: 604800

--- a/src/test/java/cotato/bookitlist/book/controller/BookControllerTest.java
+++ b/src/test/java/cotato/bookitlist/book/controller/BookControllerTest.java
@@ -8,6 +8,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 
@@ -111,6 +112,7 @@ class BookControllerTest {
     }
 
     @Test
+    @WithMockUser
     @DisplayName("isbn13을 통해 책을 등록한다.")
     void givenIsbn13_whenRegisteringBook_thenReturnBookResponse() throws Exception {
         //given
@@ -127,6 +129,7 @@ class BookControllerTest {
     }
 
     @Test
+    @WithMockUser
     @DisplayName("이미 등록된 책을 등록하면 에러를 반환한다.")
     void givenRegisteredIsbn13_whenRegisteringBook_thenReturnErrorResponse() throws Exception {
         //given
@@ -143,6 +146,7 @@ class BookControllerTest {
     }
 
     @Test
+    @WithMockUser
     @DisplayName("잘못된 형식의 isbn13으로 등록하면 에러를 반환한다.")
     void givenInvalidIsbn13_whenRegisteringBook_thenReturnErrorResponse() throws Exception {
         //given


### PR DESCRIPTION
## PR 변경된 내용
- 네이버, 카카오로 OAuth2.0 인증 구현
- OAuth2.0 인증 후 JWT 발급
- 기획에 맞게 Member Entity 컬럼 추가
- 기존에 테스트 인증에 잘 돌아가도록 수정

## 추가 내용
- refresh token, black list 추후 구현
- 추후 Role 추가해야 함
- 추후 잘못된 인증에 대한 구체적인 예외처리 해야 함. 일단 RuntimeException 처리함.

## 참조
Closes #11


