### PR TITLE
[Feat] 책 상세 API 접근 시 DB에 없는 책도 가능한 기능 추가

### DIFF
--- a/src/main/java/cotato/bookitlist/book/dto/BookDto.java
+++ b/src/main/java/cotato/bookitlist/book/dto/BookDto.java
@@ -18,9 +18,28 @@ public record BookDto(
 ) {
 
     public static BookDto from(Book entity) {
-        return new BookDto(entity.getId(), entity.getTitle(), entity.getAuthor(), entity.getPublisher(), entity.getPubDate(), entity.getDescription(), entity.getLink(), entity.getIsbn13(), entity.getPrice(), entity.getCover());
-
+        return new BookDto(entity.getId(),
+                entity.getTitle(),
+                entity.getAuthor(),
+                entity.getPublisher(),
+                entity.getPubDate(),
+                entity.getDescription(),
+                entity.getLink(),
+                entity.getIsbn13(),
+                entity.getPrice(),
+                entity.getCover());
     }
 
-
+    public static BookDto from(BookApiDto bookApiDto) {
+        return new BookDto(0L,
+                bookApiDto.title(),
+                bookApiDto.author(),
+                bookApiDto.publisher(),
+                bookApiDto.pubDate(),
+                bookApiDto.description(),
+                bookApiDto.link(),
+                bookApiDto.isbn13(),
+                bookApiDto.price(),
+                bookApiDto.cover());
+    }
 }

--- a/src/main/java/cotato/bookitlist/book/service/BookApiComponent.java
+++ b/src/main/java/cotato/bookitlist/book/service/BookApiComponent.java
@@ -58,6 +58,10 @@ public class BookApiComponent {
     public BookApiDto findByIsbn13(String isbn13) {
         JSONObject json = new JSONObject(aladinComponent.findByIsbn13(aladinKey, isbn13, "ISBN13", "JS", 20131101));
 
+        if (json.has("errorMessage")) {
+            throw new IllegalArgumentException("존재하지 않는 isbn13 입니다.");
+        }
+
         JSONObject item = json.getJSONArray("item").getJSONObject(0);
 
         BookApiDto bookApiDto = BookApiDto.of(

--- a/src/main/java/cotato/bookitlist/book/service/BookService.java
+++ b/src/main/java/cotato/bookitlist/book/service/BookService.java
@@ -33,7 +33,7 @@ public class BookService {
 
     public BookDto getBookByIsbn13(String isbn13) {
         return bookRepository.findByIsbn13(isbn13).map(BookDto::from)
-                .orElseThrow(() -> new EntityNotFoundException("등록되지 않은 isbn13입니다."));
+                .orElse(BookDto.from(getExternal(isbn13)));
     }
 
     public Page<Book> search(String keyword, Pageable pageable) {

--- a/src/main/java/cotato/bookitlist/book/service/BookService.java
+++ b/src/main/java/cotato/bookitlist/book/service/BookService.java
@@ -33,7 +33,11 @@ public class BookService {
 
     public BookDto getBookByIsbn13(String isbn13) {
         return bookRepository.findByIsbn13(isbn13).map(BookDto::from)
-                .orElse(BookDto.from(getExternal(isbn13)));
+                .orElseGet(() -> bookApiCacheService.findBookApiCacheByIsbn13(isbn13)
+                        .map(BookApiCache::getBookApiDto)
+                        .map(BookDto::from)
+                        .orElseGet(() -> BookDto.from(getExternal(isbn13)))
+                );
     }
 
     public Page<Book> search(String keyword, Pageable pageable) {

--- a/src/test/java/cotato/bookitlist/book/controller/BookControllerTest.java
+++ b/src/test/java/cotato/bookitlist/book/controller/BookControllerTest.java
@@ -195,7 +195,7 @@ class BookControllerTest {
     }
 
     @Test
-    @DisplayName("[DB] 등록되지 않은 isbn13이 주어지면 에러를 응답한다.")
+    @DisplayName("[API] 등록되지 않은 올바른 형식의 isbn13이 주어지면 API 통신을 통해 응답한다.")
     void givenUnRegisteredIsbn13_whenSearchingBook_thenReturnErrorResponse() throws Exception {
         //given
         String isbn13 = "9788966262281";
@@ -204,8 +204,15 @@ class BookControllerTest {
         mockMvc.perform(get("/books")
                         .param("isbn13", isbn13)
                 )
-                .andExpect(status().isNotFound())
-                .andExpect(jsonPath("$.message").value("등록되지 않은 isbn13입니다."))
+                .andExpect(jsonPath("$.title").exists())
+                .andExpect(jsonPath("$.author").exists())
+                .andExpect(jsonPath("$.publisher").exists())
+                .andExpect(jsonPath("$.pubDate").exists())
+                .andExpect(jsonPath("$.description").exists())
+                .andExpect(jsonPath("$.link").exists())
+                .andExpect(jsonPath("$.isbn13").exists())
+                .andExpect(jsonPath("$.price").exists())
+                .andExpect(jsonPath("$.cover").exists())
         ;
     }
 

--- a/src/test/java/cotato/bookitlist/book/controller/BookControllerTest.java
+++ b/src/test/java/cotato/bookitlist/book/controller/BookControllerTest.java
@@ -196,7 +196,7 @@ class BookControllerTest {
 
     @Test
     @DisplayName("[API] 등록되지 않은 올바른 형식의 isbn13이 주어지면 API 통신을 통해 응답한다.")
-    void givenUnRegisteredIsbn13_whenSearchingBook_thenReturnErrorResponse() throws Exception {
+    void givenUnRegisteredIsbn13_whenSearchingBook_thenReturnBookResponseFromApi() throws Exception {
         //given
         String isbn13 = "9788966262281";
 


### PR DESCRIPTION
## PR 변경된 내용
- 책 정보가 DB에 없을 경우 Redis 에 해당 호출이 있는지 검사, 그것도 없다면 API 호출로 응답. 즉 책 상세 조회 시 DB 조회 -> Redis 조회 -> API 통신으로 데이터를 얻어오게 변경

## 추가 내용
형식은 올바르지만 실제로는 없는 isbn13 입력 시 예외처리

## 참조
Closes #53 


