### PR TITLE
[Feat] 알라딘 api 조회에서 한 페이지당 최대 책 수 조절 기능 추가

### DIFF
--- a/src/main/java/cotato/bookitlist/book/controller/BookController.java
+++ b/src/main/java/cotato/bookitlist/book/controller/BookController.java
@@ -28,8 +28,10 @@ public class BookController {
     @GetMapping("/search")
     public ResponseEntity<BookApiListResponse> searchExternal(
             @RequestParam String keyword,
-            @RequestParam Integer start) {
-        return ResponseEntity.ok(bookService.searchExternal(keyword, start));
+            @RequestParam int start,
+            @RequestParam(name = "max-results", defaultValue = "5") int maxResults
+    ) {
+        return ResponseEntity.ok(bookService.searchExternal(keyword, start, maxResults));
     }
 
     @GetMapping("/external")

--- a/src/main/java/cotato/bookitlist/book/service/AladinComponent.java
+++ b/src/main/java/cotato/bookitlist/book/service/AladinComponent.java
@@ -10,7 +10,7 @@ import org.springframework.web.service.annotation.HttpExchange;
 public interface AladinComponent {
 
     @GetExchange("/ItemSearch.aspx")
-    String findAllByQuery(@RequestParam String TTBKey, @RequestParam String Query, @RequestParam String Output, @RequestParam int Start, @RequestParam int Version);
+    String findAllByQuery(@RequestParam String TTBKey, @RequestParam String Query, @RequestParam String Output, @RequestParam int Start, @RequestParam int MaxResults, @RequestParam int Version);
 
     @GetExchange("/ItemLookUp.aspx")
     String findByIsbn13(@RequestParam String TTBKey, @RequestParam String ItemId, @RequestParam String ItemIdType, @RequestParam String Output, @RequestParam int Version);

--- a/src/main/java/cotato/bookitlist/book/service/BookApiComponent.java
+++ b/src/main/java/cotato/bookitlist/book/service/BookApiComponent.java
@@ -22,8 +22,8 @@ public class BookApiComponent {
     private final AladinComponent aladinComponent;
     private final BookApiCacheService bookApiCacheService;
 
-    public BookApiListResponse findListByKeyWordAndApi(String keyword, int start) {
-        JSONObject json = new JSONObject(aladinComponent.findAllByQuery(aladinKey, keyword, "JS", start, 20131101));
+    public BookApiListResponse findListByKeyWordAndApi(String keyword, int start, int maxResults) {
+        JSONObject json = new JSONObject(aladinComponent.findAllByQuery(aladinKey, keyword, "JS", start, maxResults, 20131101));
 
         int totalResults = json.getInt("totalResults");
         int startIndex = json.getInt("startIndex");

--- a/src/main/java/cotato/bookitlist/book/service/BookService.java
+++ b/src/main/java/cotato/bookitlist/book/service/BookService.java
@@ -23,8 +23,8 @@ public class BookService {
     private final BookApiCacheService bookApiCacheService;
     private final BookRepository bookRepository;
 
-    public BookApiListResponse searchExternal(String keyword, int start) {
-        return bookApiComponent.findListByKeyWordAndApi(keyword, start);
+    public BookApiListResponse searchExternal(String keyword, int start, int maxResults) {
+        return bookApiComponent.findListByKeyWordAndApi(keyword, start, maxResults);
     }
 
     public BookApiDto getExternal(String isbn13) {

--- a/src/test/java/cotato/bookitlist/book/controller/BookControllerTest.java
+++ b/src/test/java/cotato/bookitlist/book/controller/BookControllerTest.java
@@ -43,7 +43,27 @@ class BookControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.totalResults").exists())
                 .andExpect(jsonPath("$.startIndex").exists())
-                .andExpect(jsonPath("$.itemsPerPage").exists())
+                .andExpect(jsonPath("$.itemsPerPage").value(5))
+                .andExpect(jsonPath("$.bookApiList").exists())
+        ;
+    }
+
+    @Test
+    @DisplayName("[Api] MaxResults가 주어지면 그 수 만큼 응답을 준다.")
+    void givenMaxResults_whenSearching_thenReturnBookApiResponse() throws Exception {
+        //given
+        String keyword = "aladdin";
+
+        //when&then
+        mockMvc.perform(get("/books/search")
+                        .param("keyword", keyword)
+                        .param("start", "1")
+                        .param("max-results", "10")
+                )
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.totalResults").exists())
+                .andExpect(jsonPath("$.startIndex").exists())
+                .andExpect(jsonPath("$.itemsPerPage").value(10))
                 .andExpect(jsonPath("$.bookApiList").exists())
         ;
     }


### PR DESCRIPTION
## PR 변경된 내용
- 페이지당 최대 책 수 조절 기능 추가
- default 수는 5로 설정함
- 구현한 기능 테스트 코드 작성

## 추가 내용

## 참조
Closes #85 


