### PR TITLE
[Feat] 게시글 좋아요 등록시 이미 좋아요 정보가 존재하는지 확인 로직 추가

### DIFF
--- a/src/main/java/cotato/bookitlist/post/controller/PostLikeController.java
+++ b/src/main/java/cotato/bookitlist/post/controller/PostLikeController.java
@@ -33,13 +33,12 @@ public class PostLikeController {
         return ResponseEntity.created(location).build();
     }
 
-    @DeleteMapping("/{post-like-id}")
+    @DeleteMapping
     public ResponseEntity<Void> deleteLike(
             @PathVariable("post-id") Long postId,
-            @PathVariable("post-like-id") Long postLikeId,
             @AuthenticationPrincipal AuthDetails details
     ) {
-        postLikeService.deleteLike(postId, postLikeId, details.getId());
+        postLikeService.deleteLike(postId, details.getId());
 
         return ResponseEntity.noContent().build();
     }

--- a/src/main/java/cotato/bookitlist/post/domain/PostLike.java
+++ b/src/main/java/cotato/bookitlist/post/domain/PostLike.java
@@ -5,7 +5,6 @@ import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.springframework.security.access.AccessDeniedException;
 
 @Getter
 @Entity
@@ -38,15 +37,7 @@ public class PostLike {
         post.increaseLikeCount();
     }
 
-    public void decreasePostLikeCount(Member member, Post post) {
-        if (!member.getId().equals(this.member.getId())) {
-            throw new AccessDeniedException("권한이 없는 유저입니다.");
-        }
-
-        if (!post.getId().equals(this.post.getId())) {
-            throw new IllegalArgumentException("해당 게시글의 좋아요가 아닙니다.");
-        }
-
+    public void decreasePostLikeCount() {
         post.decreaseLikeCount();
     }
 }

--- a/src/main/java/cotato/bookitlist/post/repository/PostLikeRepository.java
+++ b/src/main/java/cotato/bookitlist/post/repository/PostLikeRepository.java
@@ -3,5 +3,10 @@ package cotato.bookitlist.post.repository;
 import cotato.bookitlist.post.domain.PostLike;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface PostLikeRepository extends JpaRepository<PostLike, Long> {
+    boolean existsByPostIdAndMemberId(Long postId, Long memberId);
+
+    Optional<PostLike> findByPostIdAndMemberId(Long postId, Long memberId);
 }

--- a/src/main/java/cotato/bookitlist/post/repository/PostRepository.java
+++ b/src/main/java/cotato/bookitlist/post/repository/PostRepository.java
@@ -2,12 +2,9 @@ package cotato.bookitlist.post.repository;
 
 import cotato.bookitlist.post.domain.Post;
 import cotato.bookitlist.post.repository.querydsl.PostRepositoryCustom;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface PostRepository extends PostRepositoryCustom, JpaRepository<Post, Long> {
-    Page<Post> findByBook_Isbn13(String isbn13, Pageable pageable);
 
     int countByBook_Isbn13(String isbn13);
 }

--- a/src/test/java/cotato/bookitlist/book/controller/BookLikeControllerTest.java
+++ b/src/test/java/cotato/bookitlist/book/controller/BookLikeControllerTest.java
@@ -69,7 +69,7 @@ class BookLikeControllerTest {
 
     @Test
     @WithCustomMockUser
-    @DisplayName("이미 도서 좋아요 정보가 존재하면 에러를 반환한다.")
+    @DisplayName("중복된 좋아요를 요청하면 에러를 반환한다.")
     void givenExistedBookLike_whenRegisteringBookLike_thenErrorResponse() throws Exception {
         //given
         BookIsbn13Request request = new BookIsbn13Request("9788931514810");

--- a/src/test/java/cotato/bookitlist/post/controller/PostLikeControllerTest.java
+++ b/src/test/java/cotato/bookitlist/post/controller/PostLikeControllerTest.java
@@ -45,6 +45,21 @@ class PostLikeControllerTest {
 
     @Test
     @WithCustomMockUser
+    @DisplayName("중복된 좋아요를 요청하면 에러를 반환한다.")
+    void givenExistedPostLike_whenRegisteringPostLike_thenErrorResponse() throws Exception {
+        //given
+
+        //when & then
+        mockMvc.perform(post("/posts/2/likes")
+                        .contentType(MediaType.APPLICATION_JSON_VALUE)
+                )
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.message").value("게시글 좋아요가 이미 존재합니다."))
+        ;
+    }
+
+    @Test
+    @WithCustomMockUser
     @DisplayName("존재하지 않는 게시글에 좋아요를 요청하면 에러를 반환한다.")
     void givenNonExistedPostId_whenRegisteringPostLike_thenReturnErrorResponse() throws Exception {
         //given
@@ -53,7 +68,7 @@ class PostLikeControllerTest {
         mockMvc.perform(post("/posts/10/likes")
                         .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isNotFound())
-                .andExpect(jsonPath("$.message").value("책을 찾을 수 없습니다."))
+                .andExpect(jsonPath("$.message").value("게시글을 찾을 수 없습니다."))
         ;
     }
 
@@ -64,7 +79,7 @@ class PostLikeControllerTest {
         //given
 
         //when & then
-        mockMvc.perform(delete("/posts/2/likes/1")
+        mockMvc.perform(delete("/posts/2/likes")
                         .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isNoContent())
         ;
@@ -72,30 +87,15 @@ class PostLikeControllerTest {
 
     @Test
     @WithCustomMockUser
-    @DisplayName("잘못된 게시글 좋아요 삭제요청시 에러를 반환한다.")
-    void givenInvalidPostId_whenDeletingPostLike_thenDeletePostLike() throws Exception {
+    @DisplayName("존재하지 않는 좋아요 삭제 요청시 에러를 반환한다.")
+    void givenNonExistedPostLike_whenDeletingPostLike_thenDeletePostLike() throws Exception {
         //given
 
         //when & then
-        mockMvc.perform(delete("/posts/1/likes/1")
+        mockMvc.perform(delete("/posts/3/likes")
                         .contentType(MediaType.APPLICATION_JSON))
-                .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.message").value("해당 게시글의 좋아요가 아닙니다."))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.message").value("도서 좋아요 정보를 찾을 수 없습니다."))
         ;
     }
-
-    @Test
-    @WithCustomMockUser
-    @DisplayName("권한이 없는 유저가 좋아요 삭제요청시 에러를 반환한다.")
-    void givenInvalidMemberId_whenDeletingPostLike_thenDeletePostLike() throws Exception {
-        //given
-
-        //when & then
-        mockMvc.perform(delete("/posts/2/likes/2")
-                        .contentType(MediaType.APPLICATION_JSON))
-                .andExpect(status().isForbidden())
-                .andExpect(jsonPath("$.message").value("권한이 없는 유저입니다."))
-        ;
-    }
-
 }


### PR DESCRIPTION
## PR 변경된 내용
- 게시글 좋아요시 중복된 좋아요 학인 로직 추가
- 게시글 좋아요 취소시 게시글 좋아요 id 를 받지 않고 취소한다.
- 수정한 코드의 테스트 코드를 작성함

## 추가 내용

## 참조
Closes #99 


