### PR TITLE
[Feat] 게시글 삭제 api 구현

### DIFF
--- a/src/main/java/cotato/bookitlist/post/controller/PostController.java
+++ b/src/main/java/cotato/bookitlist/post/controller/PostController.java
@@ -7,6 +7,7 @@ import cotato.bookitlist.post.dto.requeset.PostUpdateRequest;
 import cotato.bookitlist.post.dto.response.PostCountResponse;
 import cotato.bookitlist.post.dto.response.PostListResponse;
 import cotato.bookitlist.post.dto.response.PostDetailResponse;
+import cotato.bookitlist.post.service.PostFacade;
 import cotato.bookitlist.post.service.PostService;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
@@ -32,6 +33,7 @@ public class PostController {
     private static final String POST_VIEW_COOKIE_NAME = "post_view";
 
     private final PostService postService;
+    private final PostFacade postFacade;
 
     @PostMapping
     public ResponseEntity<Void> registerPost(
@@ -108,6 +110,16 @@ public class PostController {
             @IsValidIsbn @RequestParam String isbn13
     ) {
         return ResponseEntity.ok(postService.getPostCount(isbn13));
+    }
+
+    @DeleteMapping("/{post-id}")
+    public ResponseEntity<Void> deletePost(
+            @PathVariable("post-id") Long postId,
+            @AuthenticationPrincipal AuthDetails details
+    ) {
+
+        postFacade.deletePost(postId, details.getId());
+        return ResponseEntity.noContent().build();
     }
 
     private void handlePostViewCount(HttpServletRequest request, HttpServletResponse response, Long postId) {

--- a/src/main/java/cotato/bookitlist/post/domain/entity/Post.java
+++ b/src/main/java/cotato/bookitlist/post/domain/entity/Post.java
@@ -84,4 +84,9 @@ public class Post extends BaseEntity {
     public void increaseViewCount() {
         this.viewCount++;
     }
+
+    public void deletePost() {
+        deleted = true;
+        likeCount = 0;
+    }
 }

--- a/src/main/java/cotato/bookitlist/post/repository/PostLikeRepository.java
+++ b/src/main/java/cotato/bookitlist/post/repository/PostLikeRepository.java
@@ -2,6 +2,8 @@ package cotato.bookitlist.post.repository;
 
 import cotato.bookitlist.post.domain.entity.PostLike;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.Optional;
 
@@ -9,4 +11,8 @@ public interface PostLikeRepository extends JpaRepository<PostLike, Long> {
     boolean existsByPostIdAndMemberId(Long postId, Long memberId);
 
     Optional<PostLike> findByPostIdAndMemberId(Long postId, Long memberId);
+
+    @Modifying
+    @Query(value = "delete from PostLike p where p.post.id=:postId")
+    void deleteAllByPostId(Long postId);
 }

--- a/src/main/java/cotato/bookitlist/post/repository/PostRepository.java
+++ b/src/main/java/cotato/bookitlist/post/repository/PostRepository.java
@@ -7,6 +7,8 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
+import java.util.Optional;
+
 public interface PostRepository extends PostRepositoryCustom, JpaRepository<Post, Long> {
 
     @Query("select p from Post p where p.status = 'PUBLIC'")
@@ -14,4 +16,6 @@ public interface PostRepository extends PostRepositoryCustom, JpaRepository<Post
 
     @Query("select count(p) from Post p where p.status = 'PUBLIC' and p.book.isbn13 = :isbn13")
     int countPublicPostByBook_Isbn13(String isbn13);
+
+    Optional<Post> findByIdAndMemberId(Long postId, Long memberId);
 }

--- a/src/main/java/cotato/bookitlist/post/service/PostFacade.java
+++ b/src/main/java/cotato/bookitlist/post/service/PostFacade.java
@@ -1,0 +1,17 @@
+package cotato.bookitlist.post.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class PostFacade {
+
+    private final PostService postService;
+    private final PostLikeService postLikeService;
+
+    public void deletePost(Long postId, Long memberId) {
+        postLikeService.deleteAllPostLike(postId);
+        postService.deletePost(postId, memberId);
+    }
+}

--- a/src/main/java/cotato/bookitlist/post/service/PostLikeService.java
+++ b/src/main/java/cotato/bookitlist/post/service/PostLikeService.java
@@ -43,4 +43,8 @@ public class PostLikeService {
 
         postLikeRepository.delete(postLike);
     }
+
+    public void deleteAllPostLike(Long postId) {
+        postLikeRepository.deleteAllByPostId(postId);
+    }
 }

--- a/src/main/java/cotato/bookitlist/post/service/PostService.java
+++ b/src/main/java/cotato/bookitlist/post/service/PostService.java
@@ -71,9 +71,15 @@ public class PostService {
         return PostCountResponse.of(postRepository.countPublicPostByBook_Isbn13(isbn13));
     }
 
-    @Transactional
     public void increaseViewCount(Long postId) {
         Post post = postRepository.getReferenceById(postId);
         post.increaseViewCount();
+    }
+
+    public void deletePost(Long postId, Long memberId) {
+        Post post = postRepository.findByIdAndMemberId(postId, memberId)
+                .orElseThrow(() -> new EntityNotFoundException("게시글을 찾을 수 없습니다."));
+
+        post.deletePost();
     }
 }

--- a/src/test/java/cotato/bookitlist/post/controller/PostControllerTest.java
+++ b/src/test/java/cotato/bookitlist/post/controller/PostControllerTest.java
@@ -287,7 +287,7 @@ class PostControllerTest {
         //given
 
         //when & then
-        mockMvc.perform(get("/posts/10")
+        mockMvc.perform(get("/posts/100")
                         .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isNotFound())
         ;
@@ -334,7 +334,7 @@ class PostControllerTest {
         mockMvc.perform(get("/posts/all")
                         .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.totalResults").value(7))
+                .andExpect(jsonPath("$.totalResults").value(8))
         ;
     }
 
@@ -352,5 +352,42 @@ class PostControllerTest {
                 .andExpect(jsonPath("$.count").value(4))
         ;
     }
+
+    @Test
+    @WithCustomMockUser
+    @DisplayName("게시글 id를 이용해 게시글을 삭제한다.")
+    void givenPostId_whenDeletingPost_thenDeletePost() throws Exception {
+        //given
+
+        mockMvc.perform(delete("/posts/1")
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isNoContent())
+        ;
+    }
+
+    @Test
+    @WithCustomMockUser
+    @DisplayName("좋아요가 없는 게시글 id를 이용해 게시글을 삭제한다.")
+    void givenPostIdNonPostLike_whenDeletingPost_thenDeletePost() throws Exception {
+        //given
+
+        mockMvc.perform(delete("/posts/10")
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isNoContent())
+        ;
+    }
+
+    @Test
+    @WithCustomMockUser
+    @DisplayName("비공개 게시글 id를 이용해 게시글을 삭제한다.")
+    void givenPostIdNonPrivate_whenDeletingPost_thenDeletePost() throws Exception {
+        //given
+
+        mockMvc.perform(delete("/posts/11")
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isNoContent())
+        ;
+    }
+
 }
 

--- a/src/test/java/cotato/bookitlist/post/controller/PostLikeControllerTest.java
+++ b/src/test/java/cotato/bookitlist/post/controller/PostLikeControllerTest.java
@@ -65,7 +65,7 @@ class PostLikeControllerTest {
         //given
 
         //when & then
-        mockMvc.perform(post("/posts/10/likes")
+        mockMvc.perform(post("/posts/100/likes")
                         .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isNotFound())
                 .andExpect(jsonPath("$.message").value("게시글을 찾을 수 없습니다."))

--- a/src/test/java/cotato/bookitlist/post/service/PostFacadeTest.java
+++ b/src/test/java/cotato/bookitlist/post/service/PostFacadeTest.java
@@ -1,0 +1,42 @@
+package cotato.bookitlist.post.service;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.mockito.BDDMockito.then;
+import static org.mockito.BDDMockito.willDoNothing;
+
+@DisplayName("게시글 파사드 서비스 테스트")
+@ExtendWith(MockitoExtension.class)
+class PostFacadeTest {
+
+    @InjectMocks
+    PostFacade sut;
+    @Mock
+    PostService postService;
+    @Mock
+    PostLikeService postLikeService;
+
+    @Test
+    @DisplayName("게시물 삭제요청시 게시물을 삭제한다")
+    void givenPostId_whenDeletingPost_thenDeletePost() throws Exception{
+        //given
+        Long postId = 1L;
+        Long memberId = 1L;
+        willDoNothing().given(postLikeService).deleteAllPostLike(postId);
+        willDoNothing().given(postService).deletePost(postId, memberId);
+
+        //when
+        sut.deletePost(postId, memberId);
+
+        //then
+        then(postLikeService).should().deleteAllPostLike(postId);
+        then(postService).should().deletePost(postId, memberId);
+    }
+
+
+}

--- a/src/test/java/cotato/bookitlist/post/service/PostLikeServiceTest.java
+++ b/src/test/java/cotato/bookitlist/post/service/PostLikeServiceTest.java
@@ -86,6 +86,20 @@ class PostLikeServiceTest {
         assertThat(post.getLikeCount()).isZero();
     }
 
+    @Test
+    @DisplayName("게시글 삭제시 모든 게시글 좋아요를 삭제한다.")
+    void givenPostId_whenDeletingPost_thenDeleteAllPostLike() throws Exception{
+        //given
+        Long postId = 1L;
+        willDoNothing().given(postLikeRepository).deleteAllByPostId(postId);
+
+        //when
+        sut.deleteAllPostLike(postId);
+
+        //then
+        then(postLikeRepository).should().deleteAllByPostId(postId);
+    }
+
     Post createPost(Long postId) {
         Post post = Post.of(createMember(), createBook(), "title", "content", PUBLIC, NON);
         ReflectionTestUtils.setField(post, "id", postId);

--- a/src/test/java/cotato/bookitlist/post/service/PostServiceTest.java
+++ b/src/test/java/cotato/bookitlist/post/service/PostServiceTest.java
@@ -14,6 +14,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import java.time.LocalDate;
+import java.util.Optional;
 
 import static cotato.bookitlist.post.domain.PostStatus.PUBLIC;
 import static cotato.bookitlist.post.domain.PostTemplate.NON;
@@ -46,10 +47,32 @@ class PostServiceTest {
         assertThat(post.getViewCount()).isEqualTo(1);
     }
 
-    Post createPost(Long postId) {
-        Post post = Post.of(createMember(), createBook(), "title", "content", PUBLIC, NON);
+    @Test
+    @DisplayName("게시물 삭제 요청시 게시물을 삭제한다.")
+    void givenPostId_whenDeletingPost_thenDeletePost() throws Exception{
+        //given
+        Long memberId = 1L;
+        Long postId = 1L;
+        Post post = createPost(postId, memberId);
+        given(postRepository.findByIdAndMemberId(postId, memberId)).willReturn(Optional.of(post));
+
+        //when
+        sut.deletePost(postId, memberId);
+
+        //then
+        then(postRepository).should().findByIdAndMemberId(postId, memberId);
+        assertThat(post.isDeleted()).isTrue();
+        assertThat(post.getLikeCount()).isZero();
+    }
+
+    Post createPost(Long postId, Long memberId) {
+        Post post = Post.of(createMember(memberId), createBook(), "title", "content", PUBLIC, NON);
         ReflectionTestUtils.setField(post, "id", postId);
         return post;
+    }
+
+    Post createPost(Long postId) {
+        return createPost(postId, 1L);
     }
 
     Book createBook() {

--- a/src/test/resources/data.sql
+++ b/src/test/resources/data.sql
@@ -20,7 +20,8 @@ VALUES ('Aladdin and His Lamp (반양장) - and the Other Stories', 'Harriette T
 
 INSERT INTO member (email, name, oauth2Id, auth_provider, follow_count, deleted, created_at, modified_at)
 VALUES ('test@gmail.com', 'test', 'test', 'KAKAO', 0, false, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
-       ('test2@gmail.com', 'test2', 'test2', 'KAKAO', 0, false, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
+       ('test2@gmail.com', 'test2', 'test2', 'KAKAO', 0, false, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+       ('test2@gmail.com', 'test2', 'test3', 'KAKAO', 0, false, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
 
 INSERT INTO post (member_id, book_id, title, content, status, template, like_count, view_count, deleted)
 values (1, 1, 'posttitle', 'postcontent', 'PUBLIC', 'NON', 0, 0, false),
@@ -31,7 +32,11 @@ values (1, 1, 'posttitle', 'postcontent', 'PUBLIC', 'NON', 0, 0, false),
        (2, 2, 'posTitle', 'ptent', 'PUBLIC', 'NON', 0, 0, false),
        (2, 2, 'positle', 'postent', 'PUBLIC', 'NON', 0, 0, false),
        (2, 2, 'privateTitle', 'privateContent', 'PRIVATE', 'NON', 0, 0, false),
-       (2, 2, 'privateTitle', 'first<============================>second<============================>third<============================>fourth', 'PUBLIC', 'TEMPLATE', 0, 0, false);
+       (2, 2, 'privateTitle',
+        'first<============================>second<============================>third<============================>fourth',
+        'PUBLIC', 'TEMPLATE', 0, 0, false),
+       (1, 2, 'posttitle', 'postcontent', 'PUBLIC', 'NON', 0, 0, false),
+       (1, 2, 'posttitle', 'postcontent', 'PRIVATE', 'NON', 0, 0, false);
 
 INSERT INTO review (member_id, book_id, content, status, like_count, view_count, deleted)
 VALUES (1, 1, 'reviewContent', 'PUBLIC', 0, 0, false),
@@ -42,7 +47,9 @@ VALUES (1, 1, 'reviewContent', 'PUBLIC', 0, 0, false),
        (2, 2, 'reContent2', 'PUBLIC', 0, 0, false);
 
 INSERT INTO post_like (member_id, post_id)
-VALUES (1, 2),
+VALUES (2, 1),
+       (3, 1),
+       (1, 2),
        (2, 2);
 
 INSERT INTO review_like (member_id, review_id)


### PR DESCRIPTION
## PR 변경된 내용
- 게시물 삭제 기능 구현 및 테스트 구현
- 게시물 삭제시 `PostService` 와 `PostLikeService` 의 순환참조를 막기위해 `Facade` 패턴을 활용함
- 모든 게시물 좋아요는 삭제하고 조회수는 그대로 둔다.
- Soft 삭제를 활용함

## 추가 내용

## 참조
Closes #115 


