### PR TITLE
[Feat] API에 사용하지 않는 book id 값 응답에서 삭제하기

### DIFF
--- a/src/main/java/cotato/bookitlist/book/dto/BookDto.java
+++ b/src/main/java/cotato/bookitlist/book/dto/BookDto.java
@@ -5,7 +5,6 @@ import cotato.bookitlist.book.domain.entity.Book;
 import java.time.LocalDate;
 
 public record BookDto(
-        Long bookId,
         String title,
         String author,
         String publisher,
@@ -18,7 +17,7 @@ public record BookDto(
 ) {
 
     public static BookDto from(Book entity) {
-        return new BookDto(entity.getId(),
+        return new BookDto(
                 entity.getTitle(),
                 entity.getAuthor(),
                 entity.getPublisher(),
@@ -27,11 +26,12 @@ public record BookDto(
                 entity.getLink(),
                 entity.getIsbn13(),
                 entity.getPrice(),
-                entity.getCover());
+                entity.getCover()
+        );
     }
 
     public static BookDto from(BookApiDto bookApiDto) {
-        return new BookDto(0L,
+        return new BookDto(
                 bookApiDto.title(),
                 bookApiDto.author(),
                 bookApiDto.publisher(),
@@ -40,6 +40,7 @@ public record BookDto(
                 bookApiDto.link(),
                 bookApiDto.isbn13(),
                 bookApiDto.price(),
-                bookApiDto.cover());
+                bookApiDto.cover()
+        );
     }
 }

--- a/src/main/java/cotato/bookitlist/book/dto/response/BookResponse.java
+++ b/src/main/java/cotato/bookitlist/book/dto/response/BookResponse.java
@@ -5,7 +5,6 @@ import cotato.bookitlist.book.dto.BookDto;
 import java.time.LocalDate;
 
 public record BookResponse(
-        Long bookId,
         String title,
         String author,
         String publisher,
@@ -18,7 +17,16 @@ public record BookResponse(
 ) {
 
     public static BookResponse fromBookDto(BookDto dto) {
-        return new BookResponse(dto.bookId(), dto.title(), dto.author(), dto.publisher(), dto.pubDate(), dto.description(), dto.link(), dto.isbn13(), dto.price(), dto.cover());
+        return new BookResponse(
+                dto.title(),
+                dto.author(),
+                dto.publisher(),
+                dto.pubDate(),
+                dto.description(),
+                dto.link(),
+                dto.isbn13(),
+                dto.price(), dto.cover()
+        );
     }
 
 }

--- a/src/test/java/cotato/bookitlist/book/controller/BookControllerTest.java
+++ b/src/test/java/cotato/bookitlist/book/controller/BookControllerTest.java
@@ -201,7 +201,6 @@ class BookControllerTest {
                         .param("isbn13", isbn13)
                 )
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.bookId").exists())
                 .andExpect(jsonPath("$.title").exists())
                 .andExpect(jsonPath("$.author").exists())
                 .andExpect(jsonPath("$.publisher").exists())
@@ -245,7 +244,15 @@ class BookControllerTest {
         //when&then
         mockMvc.perform(get("/books/" + bookId))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.bookId").value(1L))
+                .andExpect(jsonPath("$.title").exists())
+                .andExpect(jsonPath("$.author").exists())
+                .andExpect(jsonPath("$.publisher").exists())
+                .andExpect(jsonPath("$.pubDate").exists())
+                .andExpect(jsonPath("$.description").exists())
+                .andExpect(jsonPath("$.link").exists())
+                .andExpect(jsonPath("$.isbn13").exists())
+                .andExpect(jsonPath("$.price").exists())
+                .andExpect(jsonPath("$.cover").exists())
         ;
     }
 


### PR DESCRIPTION
## PR 변경된 내용
- 사용하지 않는 bookId 값을 API 응답에서 제거
- 응답에서 bookId 제거로 인한 테스트 변경

## 추가 내용

## 참조
Closes #112 


