### PR TITLE
[Feat] 유저 프로필 비공개 시 한줄요약도 비공개 상태로 하는 기능 구현

### DIFF
--- a/src/main/java/cotato/bookitlist/review/repository/querydsl/ReviewRepositoryCustomImpl.java
+++ b/src/main/java/cotato/bookitlist/review/repository/querydsl/ReviewRepositoryCustomImpl.java
@@ -7,6 +7,7 @@ import com.querydsl.core.types.dsl.NumberPath;
 import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import cotato.bookitlist.member.domain.ProfileStatus;
 import cotato.bookitlist.review.domain.ReviewStatus;
 import cotato.bookitlist.review.dto.ReviewDetailDto;
 import cotato.bookitlist.review.dto.ReviewDto;
@@ -18,6 +19,7 @@ import org.springframework.data.support.PageableExecutionUtils;
 import java.util.List;
 import java.util.Optional;
 
+import static cotato.bookitlist.member.domain.QMember.member;
 import static cotato.bookitlist.review.domain.entity.QReview.review;
 import static cotato.bookitlist.review.domain.entity.QReviewLike.reviewLike;
 
@@ -46,7 +48,8 @@ public class ReviewRepositoryCustomImpl implements ReviewRepositoryCustom {
                         )
                 )
                 .from(review)
-                .where(review.book.isbn13.eq(isbn13), review.status.eq(ReviewStatus.PUBLIC))
+                .join(review.member, member)
+                .where(review.book.isbn13.eq(isbn13), review.status.eq(ReviewStatus.PUBLIC), review.member.profileStatus.eq(ProfileStatus.PUBLIC))
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize())
                 .fetch();
@@ -82,7 +85,8 @@ public class ReviewRepositoryCustomImpl implements ReviewRepositoryCustom {
                         )
                 )
                 .from(review)
-                .where(review.id.eq(reviewId), review.status.eq(ReviewStatus.PUBLIC))
+                .join(review.member, member)
+                .where(review.id.eq(reviewId), review.status.eq(ReviewStatus.PUBLIC), review.member.profileStatus.eq(ProfileStatus.PUBLIC))
                 .fetchOne());
     }
 

--- a/src/test/java/cotato/bookitlist/fixture/PostFixture.java
+++ b/src/test/java/cotato/bookitlist/fixture/PostFixture.java
@@ -1,17 +1,17 @@
 package cotato.bookitlist.fixture;
 
+import cotato.bookitlist.post.domain.PostStatus;
 import cotato.bookitlist.post.domain.entity.Post;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import static cotato.bookitlist.fixture.BookFixture.createBook;
 import static cotato.bookitlist.fixture.MemberFixture.createMember;
-import static cotato.bookitlist.post.domain.PostStatus.PUBLIC;
 import static cotato.bookitlist.post.domain.PostTemplate.NON;
 
 public class PostFixture {
 
     public static Post createPost(Long postId, Long memberId) {
-        Post post = Post.of(createMember(memberId), createBook(), "title", "content", PUBLIC, NON);
+        Post post = Post.of(createMember(memberId), createBook(), "title", "content", PostStatus.PUBLIC, NON);
         ReflectionTestUtils.setField(post, "id", postId);
         return post;
     }

--- a/src/test/java/cotato/bookitlist/fixture/ReviewFixture.java
+++ b/src/test/java/cotato/bookitlist/fixture/ReviewFixture.java
@@ -1,15 +1,15 @@
 package cotato.bookitlist.fixture;
 
+import cotato.bookitlist.review.domain.ReviewStatus;
 import cotato.bookitlist.review.domain.entity.Review;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import static cotato.bookitlist.fixture.BookFixture.createBook;
 import static cotato.bookitlist.fixture.MemberFixture.createMember;
-import static cotato.bookitlist.review.domain.ReviewStatus.PUBLIC;
 
 public class ReviewFixture {
     public static Review createReview(Long reviewId) {
-        Review review = Review.of(createMember(), createBook(), "content", PUBLIC);
+        Review review = Review.of(createMember(), createBook(), "content", ReviewStatus.PUBLIC);
         ReflectionTestUtils.setField(review, "id", reviewId);
         return review;
     }

--- a/src/test/java/cotato/bookitlist/post/controller/PostControllerTest.java
+++ b/src/test/java/cotato/bookitlist/post/controller/PostControllerTest.java
@@ -2,6 +2,7 @@ package cotato.bookitlist.post.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import cotato.bookitlist.annotation.WithCustomMockUser;
+import cotato.bookitlist.post.domain.PostStatus;
 import cotato.bookitlist.post.dto.requeset.PostRegisterRequest;
 import cotato.bookitlist.post.dto.requeset.PostUpdateRequest;
 import jakarta.servlet.http.Cookie;
@@ -19,7 +20,6 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
-import static cotato.bookitlist.post.domain.PostStatus.PUBLIC;
 import static cotato.bookitlist.post.domain.PostTemplate.NON;
 import static cotato.bookitlist.post.domain.PostTemplate.TEMPLATE;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
@@ -45,7 +45,7 @@ class PostControllerTest {
     @DisplayName("DB에 등록된 책에 게시글을 생성한다")
     void givenPostRegisterRequest_whenRegisteringPost_thenRegisterPost() throws Exception {
         //given
-        PostRegisterRequest request = new PostRegisterRequest("9788931514810", "title", "content", PUBLIC, NON);
+        PostRegisterRequest request = new PostRegisterRequest("9788931514810", "title", "content", PostStatus.PUBLIC, NON);
 
         //when & then
         mockMvc.perform(post("/posts")
@@ -61,7 +61,7 @@ class PostControllerTest {
     @DisplayName("Template을 활용하여 게시글을 생성한다")
     void givenTemplateRequest_whenRegisteringPost_thenRegisterPost() throws Exception {
         //given
-        PostRegisterRequest request = new PostRegisterRequest("9788931514810", "title", "first<============================>second<============================>third<============================>fourth", PUBLIC, TEMPLATE);
+        PostRegisterRequest request = new PostRegisterRequest("9788931514810", "title", "first<============================>second<============================>third<============================>fourth", PostStatus.PUBLIC, TEMPLATE);
 
         //when & then
         mockMvc.perform(post("/posts")
@@ -78,7 +78,7 @@ class PostControllerTest {
     @DisplayName("잘못된 split 문자열이 오면 에러를 반환한다.")
     void givenInvalidSplitString_whenRegisteringPost_thenReturnErrorResponse() throws Exception {
         //given
-        PostRegisterRequest request = new PostRegisterRequest("9788931514810", "title", "first<===========================>second<============================>third<============================>fourth", PUBLIC, TEMPLATE);
+        PostRegisterRequest request = new PostRegisterRequest("9788931514810", "title", "first<===========================>second<============================>third<============================>fourth", PostStatus.PUBLIC, TEMPLATE);
 
         //when & then
         mockMvc.perform(post("/posts")
@@ -94,7 +94,7 @@ class PostControllerTest {
     @DisplayName("DB에 존재하지 않는 책으로 게시글을 생성요청하면 API 통신을 통해 책을 등록하고 게시글을 등록한다.")
     void givenNonExistedInDataBaseIsbn13_whenRegisteringPost_thenRegisterBookAndPost() throws Exception {
         //given
-        PostRegisterRequest request = new PostRegisterRequest("9791193235119", "title", "content", PUBLIC, NON);
+        PostRegisterRequest request = new PostRegisterRequest("9791193235119", "title", "content", PostStatus.PUBLIC, NON);
 
         //when & then
         mockMvc.perform(post("/posts")
@@ -110,7 +110,7 @@ class PostControllerTest {
     @DisplayName("존재하지 않은 책으로 게시글을 생성요청하면 에러를 반환한다.")
     void givenNonExistedIsbn13_whenRegisteringPost_thenReturnErrorResponse() throws Exception {
         //given
-        PostRegisterRequest request = new PostRegisterRequest("9782345678908", "title", "content", PUBLIC, NON);
+        PostRegisterRequest request = new PostRegisterRequest("9782345678908", "title", "content", PostStatus.PUBLIC, NON);
 
         //when & then
         mockMvc.perform(post("/posts")
@@ -141,11 +141,11 @@ class PostControllerTest {
 
         return List.of(
                 new PostRegisterRequest("9788931514810", "", "content", null, NON),
-                new PostRegisterRequest("9788931514810", "", "content", PUBLIC, NON),
-                new PostRegisterRequest("9788931514810", "title", "", PUBLIC, NON),
-                new PostRegisterRequest("9788931514810", "", "", PUBLIC, NON),
-                new PostRegisterRequest("9788931514810", tooLongTitle, "", PUBLIC, NON),
-                new PostRegisterRequest("9788931514810", tooLongTitle, "content", PUBLIC, NON)
+                new PostRegisterRequest("9788931514810", "", "content", PostStatus.PUBLIC, NON),
+                new PostRegisterRequest("9788931514810", "title", "", PostStatus.PUBLIC, NON),
+                new PostRegisterRequest("9788931514810", "", "", PostStatus.PUBLIC, NON),
+                new PostRegisterRequest("9788931514810", tooLongTitle, "", PostStatus.PUBLIC, NON),
+                new PostRegisterRequest("9788931514810", tooLongTitle, "content", PostStatus.PUBLIC, NON)
         );
     }
 
@@ -154,7 +154,7 @@ class PostControllerTest {
     @DisplayName("게시글을 수정한다.")
     void givenPostUpdateRequest_whenUpdatingPost_thenUpdatePost() throws Exception {
         //given
-        PostUpdateRequest request = new PostUpdateRequest("updateTitle", "updateContent", PUBLIC, NON);
+        PostUpdateRequest request = new PostUpdateRequest("updateTitle", "updateContent", PostStatus.PUBLIC, NON);
 
         //when & then
         mockMvc.perform(put("/posts/1")
@@ -170,7 +170,7 @@ class PostControllerTest {
     @DisplayName("권한이 없는 게시글을 수정하면 에러를 반환한다.")
     void givenInvalidMemberId_whenUpdatingPost_thenReturnErrorResponse() throws Exception {
         //given
-        PostUpdateRequest request = new PostUpdateRequest("updateTitle", "updateContent", PUBLIC, NON);
+        PostUpdateRequest request = new PostUpdateRequest("updateTitle", "updateContent", PostStatus.PUBLIC, NON);
 
         //when & then
         mockMvc.perform(put("/posts/2")
@@ -202,11 +202,11 @@ class PostControllerTest {
 
         return List.of(
                 new PostUpdateRequest("title", "content", null, NON),
-                new PostUpdateRequest("", "content", PUBLIC, NON),
-                new PostUpdateRequest("title", "", PUBLIC, NON),
-                new PostUpdateRequest("", "", PUBLIC, NON),
-                new PostUpdateRequest(tooLongTitle, "", PUBLIC, NON),
-                new PostUpdateRequest(tooLongTitle, "content", PUBLIC, NON)
+                new PostUpdateRequest("", "content", PostStatus.PUBLIC, NON),
+                new PostUpdateRequest("title", "", PostStatus.PUBLIC, NON),
+                new PostUpdateRequest("", "", PostStatus.PUBLIC, NON),
+                new PostUpdateRequest(tooLongTitle, "", PostStatus.PUBLIC, NON),
+                new PostUpdateRequest(tooLongTitle, "content", PostStatus.PUBLIC, NON)
         );
     }
 

--- a/src/test/java/cotato/bookitlist/review/controller/ReviewControllerTest.java
+++ b/src/test/java/cotato/bookitlist/review/controller/ReviewControllerTest.java
@@ -2,6 +2,7 @@ package cotato.bookitlist.review.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import cotato.bookitlist.annotation.WithCustomMockUser;
+import cotato.bookitlist.review.domain.ReviewStatus;
 import cotato.bookitlist.review.dto.request.ReviewRegisterRequest;
 import cotato.bookitlist.review.dto.request.ReviewUpdateRequest;
 import jakarta.servlet.http.Cookie;
@@ -19,7 +20,6 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
-import static cotato.bookitlist.review.domain.ReviewStatus.PUBLIC;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
@@ -42,7 +42,7 @@ class ReviewControllerTest {
     @DisplayName("DB에 등록된 책에 한줄요약을 생성한다")
     void givenReviewRegisterRequest_whenRegisteringReview_thenRegisterRegister() throws Exception {
         //given
-        ReviewRegisterRequest request = new ReviewRegisterRequest("9788931514810", "content", PUBLIC);
+        ReviewRegisterRequest request = new ReviewRegisterRequest("9788931514810", "content", ReviewStatus.PUBLIC);
 
         //when & then
         mockMvc.perform(post("/reviews")
@@ -58,7 +58,7 @@ class ReviewControllerTest {
     @DisplayName("DB에 존재하지 않는 책으로 한줄요약을 생성요청하면 API 통신을 통해 책을 등록하고 한줄요약을 등록한다.")
     void givenNonExistedInDataBaseIsbn13_whenRegisteringReview_thenRegisterBookAndReview() throws Exception {
         //given
-        ReviewRegisterRequest request = new ReviewRegisterRequest("9791193235119", "content", PUBLIC);
+        ReviewRegisterRequest request = new ReviewRegisterRequest("9791193235119", "content", ReviewStatus.PUBLIC);
 
         //when & then
         mockMvc.perform(post("/reviews")
@@ -74,7 +74,7 @@ class ReviewControllerTest {
     @DisplayName("존재하지 않은 책으로 한줄요약을 생성요청하면 에러를 반환한다.")
     void givenNonExistedIsbn13_whenRegisteringReview_thenReturnErrorResponse() throws Exception {
         //given
-        ReviewRegisterRequest request = new ReviewRegisterRequest("9782345678908", "content", PUBLIC);
+        ReviewRegisterRequest request = new ReviewRegisterRequest("9782345678908", "content", ReviewStatus.PUBLIC);
 
         //when & then
         mockMvc.perform(post("/reviews")
@@ -104,8 +104,8 @@ class ReviewControllerTest {
         String tooLongContent = "TooooooooooooooooooooooooooooooooooooooooooooooLong"; // 51글자
 
         return List.of(
-                new ReviewRegisterRequest("9788931514810", "", PUBLIC),
-                new ReviewRegisterRequest("9788931514810", tooLongContent, PUBLIC)
+                new ReviewRegisterRequest("9788931514810", "", ReviewStatus.PUBLIC),
+                new ReviewRegisterRequest("9788931514810", tooLongContent, ReviewStatus.PUBLIC)
         );
     }
 
@@ -114,7 +114,7 @@ class ReviewControllerTest {
     @DisplayName("한줄요약을 수정한다.")
     void givenReviewUpdateRequest_whenUpdatingReview_thenUpdateReview() throws Exception {
         //given
-        ReviewUpdateRequest request = new ReviewUpdateRequest("updateContent", PUBLIC);
+        ReviewUpdateRequest request = new ReviewUpdateRequest("updateContent", ReviewStatus.PUBLIC);
 
         //when & then
         mockMvc.perform(put("/reviews/1")
@@ -130,7 +130,7 @@ class ReviewControllerTest {
     @DisplayName("권한이 없는 한줄요약를 수정하면 에러를 반환한다.")
     void givenInvalidMemberId_whenUpdatingReview_thenReturnErrorResponse() throws Exception {
         //given
-        ReviewUpdateRequest request = new ReviewUpdateRequest("updateContent", PUBLIC);
+        ReviewUpdateRequest request = new ReviewUpdateRequest("updateContent", ReviewStatus.PUBLIC);
 
         //when & then
         mockMvc.perform(put("/reviews/2")
@@ -161,8 +161,8 @@ class ReviewControllerTest {
         String tooLongContent = "TooooooooooooooooooooooooooooooooooooooooooooooLong"; // 51글자
 
         return List.of(
-                new ReviewUpdateRequest("", PUBLIC),
-                new ReviewUpdateRequest(tooLongContent, PUBLIC)
+                new ReviewUpdateRequest("", ReviewStatus.PUBLIC),
+                new ReviewUpdateRequest(tooLongContent, ReviewStatus.PUBLIC)
         );
     }
 


### PR DESCRIPTION
## PR 변경된 내용
- 유저가 프로필을 비공개로 변경하면 그 유저가 작성한 한줄요약도 비공개처리된다. 유저가 프로필을 다시 공개로 변경하면 이전에 공개였던 한줄요약은 다시 공개로 돌아온다.
즉, 공개 한줄요약은 유저의 프로필과 한줄요약이 모두 공개인 것이다.

## 추가 내용
Status 가 Profile, Post, Review 세 종류가 있으므로 static import를 없애고 소속 클래스를 더 잘 나타내도록 변경

## 참조
Closes #125 


