### PR TITLE
[Fix] MySQL 설정에 따른 테이블명 대소문자 구분 오류 수정

### DIFF
--- a/src/main/java/cotato/bookitlist/book/repository/BookRepository.java
+++ b/src/main/java/cotato/bookitlist/book/repository/BookRepository.java
@@ -21,6 +21,6 @@ public interface BookRepository extends JpaRepository<Book, Long> {
     @Query("select b from BookLike l join l.book b join l.member m where m.id = :memberId")
     Page<Book> findLikeBookByMemberId(Long memberId, Pageable pageable);
 
-    @Query(value = "select * from Book b order by RAND() LIMIT :count", nativeQuery = true)
+    @Query(value = "select * from book b order by RAND() LIMIT :count", nativeQuery = true)
     List<Book> findBooksByRandom(int count);
 }


### PR DESCRIPTION
## PR 변경된 내용
- 네이티브 쿼리 이용 중 테이블명에서 대소문자를 혼용해서 오류가 난다. 소문자로 바꿔 오류를 해결한다.

## 추가 내용

## 참조
Closes #156 