### PR TITLE
[Fix] 네이버 로그인 attribute 이름 재설정

### DIFF
--- a/src/main/java/cotato/bookitlist/config/security/oauth/NaverOAuth2User.java
+++ b/src/main/java/cotato/bookitlist/config/security/oauth/NaverOAuth2User.java
@@ -16,6 +16,6 @@ public class NaverOAuth2User extends OAuth2UserInfo {
     }
 
     public String getName() {
-        return (String) this.attributes.get("name");
+        return (String) this.attributes.get("nickname");
     }
 }


### PR DESCRIPTION
## PR 변경된 내용
- 네이버 attribute 이름이 name 으로 되어있었던 것을 nickname 으로 수정

## 추가 내용

## 참조
Closes #184 

